### PR TITLE
#101 iOS NSCameraUsageDescription Invalid purpose string value type

### DIFF
--- a/ios/Runner/Info-Debug.plist
+++ b/ios/Runner/Info-Debug.plist
@@ -29,12 +29,7 @@
 		<string>_dartobservatory._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-    <dict>
-        <key>en</key>
-        <string>Allowing camera access enables you to take pictures of your food, which we will use to calculate its calories and provide you with nutritional information. We will not access your camera for any other purpose without your permission.</string>
-        <key>sv</key>
-        <string>Genom att tillåta kameraåtkomst kan du ta bilder av din mat, som vi kommer att använda för att beräkna dess kalorier och ge dig näringsinformation. Vi kommer inte att komma åt din kamera för något annat ändamål utan ditt tillstånd.</string>
-    </dict>
+    <string>Allowing camera access enables you to take pictures of your food, which we will use to calculate its calories and provide you with nutritional information. We will not access your camera for any other purpose without your permission.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios/Runner/Info-Release.plist
+++ b/ios/Runner/Info-Release.plist
@@ -25,12 +25,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
     <key>NSCameraUsageDescription</key>
-    <dict>
-        <key>en</key>
-        <string>Allowing camera access enables you to take pictures of your food, which we will use to calculate its calories and provide you with nutritional information. We will not access your camera for any other purpose without your permission.</string>
-        <key>sv</key>
-        <string>Genom att tillåta kameraåtkomst kan du ta bilder av din mat, som vi kommer att använda för att beräkna dess kalorier och ge dig näringsinformation. Vi kommer inte att komma åt din kamera för något annat ändamål utan ditt tillstånd.</string>
-    </dict>
+    <string>Allowing camera access enables you to take pictures of your food, which we will use to calculate its calories and provide you with nutritional information. We will not access your camera for any other purpose without your permission.</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
ITMS-90952: Invalid purpose string value type - The value for the NSCameraUsageDescription Info.plist key in “Runner.app” needs to be a string.