### PR TITLE
#114 import PrivacyDashboardiOS sdk instead of iGrantioSDK

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Flutter
-import iGrantioSDK
+import PrivacyDashboardiOS
 import ama_ios_sdk
 import SwiftMessages
 


### PR DESCRIPTION
import PrivacyDashboardiOS sdk instead of iGrantioSDK in AppDelegate file.