### PR TITLE
#122 ios - PrivacyDashboard SDK version specifying removed

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,7 +37,7 @@ target 'Runner' do
 #  use_frameworks!
   use_modular_headers!
 
-  pod 'PrivacyDashboardiOS','2023.10.3'
+  pod 'PrivacyDashboardiOS'
   pod 'ama-ios-sdk'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))


### PR DESCRIPTION
Removed the 'PrivacyDashboardiOS' SDK version number to prevent the need for updating it every time there's a change in the SDK.  This modification ensures that the code will automatically execute the latest version of the SDK.