### PR TITLE
Optimize the usage of OTP

### DIFF
--- a/lib/app/modules/login/controllers/login_controller.dart
+++ b/lib/app/modules/login/controllers/login_controller.dart
@@ -5,11 +5,15 @@ import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:get/get.dart';
 import 'package:intl_phone_number_input/intl_phone_number_input.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
 
 import '../../../data/model/login/LoginResponse.dart';
 import '../../../data/repository/user_repository_impl.dart';
 import '/app/core/base/base_controller.dart';
-
+String? sessionToken;
+const int timeWindow = 1 * 60 * 1000; // 1 minute time window
+const int maxMessagesPerWindow = 3;
 class LoginController extends BaseController {
   PhoneNumber number = PhoneNumber(isoCode: 'SE');
   final UserRepositoryImpl _impl = UserRepositoryImpl();
@@ -17,7 +21,9 @@ class LoginController extends BaseController {
   var sharePhoneNumber = "".obs;
   var isControl = true.obs;
   String? isdCode;
-
+  int currentTime = 0;
+  int lastMessageTime = 0;
+  int messageCount = 0;
   loginUser() async {
     String pattern = r'(^(?:[+0]9)?[0-9]{10,12}$)';
     RegExp regExp = RegExp(pattern);
@@ -31,29 +37,57 @@ class LoginController extends BaseController {
       GetSnackToast(message:appLocalization.loginValidPhoneNumberValidationText);
     }
     else{
-      sharePhoneNumber.value = isdCode! + phoneNumberController.text;
-      debugPrint("shared number:" + sharePhoneNumber.value);
-      LoginRequest request =
-      LoginRequest(mobile_number: isdCode! + phoneNumberController.text);
-      try {
-        LoginResponse response = await _impl.login(request);
-        if (response.msg == "OTP sent") {
-          hideLoading();
-          phoneNumberController.clear();
-          isControl.value = true;
-          Get.to(OtpView());
-          phoneNumberController.clear();
-        }
-      } catch (e) {
-        // showToast((e as ApiException).message);
-        GetSnackToast(message: (e as ApiException).message);
-
-        hideLoading();
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      int currentTime = DateTime.now().millisecondsSinceEpoch;
+      sessionToken = generateSessionToken(phoneNumberController.text); // Generate session token
+      lastMessageTime = prefs.getInt('last_message_time_$sessionToken') ?? 0;
+      messageCount = prefs.getInt('message_count_$sessionToken') ?? 0;
+      // Maximum messages allowed per time window
+      if (currentTime - lastMessageTime >= timeWindow) {
+        // Reset the rate limit if the time window has elapsed
+        messageCount = 0;
+        lastMessageTime = currentTime;
       }
-      finally{
+      if (messageCount >= maxMessagesPerWindow) {
+        // Rate limit exceeded, display an error message or take appropriate action
         hideLoading();
+        GetSnackToast(
+            message:  appLocalization.otpLimitExceeded,);
+      }
+      else{
+        // Within the rate limit, proceed with OTP request
+        // Increment message count and update last message time
+        messageCount++;
+        lastMessageTime = currentTime;
+        await prefs.setInt('message_count_$sessionToken', messageCount);
+        await prefs.setInt('last_message_time_$sessionToken', lastMessageTime);
+        // Execute the code to request OTP
+        sharePhoneNumber.value = isdCode! + phoneNumberController.text;
+        debugPrint("shared number:" + sharePhoneNumber.value);
+        LoginRequest request =
+        LoginRequest(mobile_number: isdCode! + phoneNumberController.text);
+        try {
+          LoginResponse response = await _impl.login(request);
+          if (response.msg == "OTP sent") {
+            hideLoading();
+            phoneNumberController.clear();
+            isControl.value = true;
+            Get.to(OtpView());
+            phoneNumberController.clear();
+          }
+        } catch (e) {
+          GetSnackToast(message: (e as ApiException).message);
+          hideLoading();
+        }
+        finally{
+          hideLoading();
+        }
       }
     }
-
+  }
+  String generateSessionToken(String phoneNumber) {
+    return Uuid()
+        .v5(Uuid.NAMESPACE_URL, phoneNumber)
+        .toString(); // Generate session token using UUID v5
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -94,6 +94,7 @@
   "insightsDexcomTitle":"Dexcom Login",
   "insightsDexcomContent":"Please login to Dexcom to get your estimated glucose values",
   "insightsOk":"Ok",
-  "insightsCancel":"Cancel"
+  "insightsCancel":"Cancel",
+  "otpLimitExceeded":"OTP request limit exceeded. Please try again after sometime."
 
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -94,5 +94,6 @@
   "insightsDexcomTitle":"Dexcom inloggning",
   "insightsDexcomContent":"Logga in på Dexcom för att få dina uppskattade glukosvärden",
   "insightsOk":"Okej",
-  "insightsCancel":"Annullera"
+  "insightsCancel":"Annullera",
+  "otpLimitExceeded":"Gränsen för OTP-begäran har överskridits. Försök igen efter en stund."
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   firebase_core: ^2.13.0
   firebase_core_platform_interface: 4.8.0
   firebase_crashlytics: ^3.3.1
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
 Optimize the usage of OTP.
Users are restricted from requesting OTP more than 3 times within a 60-second timeframe. If the limit is exceeded, users will need to wait for 60 seconds before being allowed to retry OTP.